### PR TITLE
Changed to Multi-Case Active Pattern

### DIFF
--- a/2014-09-MakingChange/FSharp-with-ActivePatterns-and_Record.fs
+++ b/2014-09-MakingChange/FSharp-with-ActivePatterns-and_Record.fs
@@ -1,10 +1,12 @@
-module Change
-
-let (|Negative|_|) x =
-    if x < 0 then Some Negative
-    else None    
+﻿module Change
 
 type State = { Denominations: int list; Amount: int }
+
+let (|NegativeAmount|ZeroAmount|ZeroCoins|Remaining|) (state: State) =
+    if state.Amount < 0 then NegativeAmount
+    elif state.Amount = 0 then ZeroAmount
+    elif state.Denominations = [] then ZeroCoins
+    else Remaining (state.Denominations.Head, state.Denominations.Tail, state.Amount)    
 
 let UsdCoins = [100; 50; 25; 10; 5; 1]
 let EuroCoins = [100; 50; 20; 10; 5; 2; 1]
@@ -12,12 +14,21 @@ let EuroCoins = [100; 50; 20; 10; 5; 2; 1]
 let WaysOfMakingChange denominations amount =
     let rec WaysOfMakingChange (state: State) =
         match state with
-        | { Amount = Negative } -> 0
-        | { Amount = 0 } -> 1
-        | { Denominations = [] } -> 0
-        | { Denominations = first::rest } -> 
-            WaysOfMakingChange { state with Denominations = rest } 
+        | ZeroAmount -> 1
+        | ZeroCoins -> 0
+        | NegativeAmount -> 0
+        | Remaining (firstCoin, restOfCoins, amount) -> 
+            WaysOfMakingChange { state with Denominations = restOfCoins } 
             + 
-            WaysOfMakingChange { state with Amount = state.Amount - first }
+            WaysOfMakingChange { state with Amount = amount - firstCoin }
 
     WaysOfMakingChange { Denominations = denominations; Amount = amount }
+
+
+// Using Partial Application we can create change counters for any denominstaions
+let UsdCounter = WaysOfMakingChange UsdCoins
+let EuroCounter = WaysOfMakingChange EuroCoins
+let adHocCounter = WaysOfMakingChange [2;4;8]
+
+
+


### PR DESCRIPTION
Changed the Active Pattern to Multi-Case so every line in the Pattern Match can use it.
Added some examples of using Partial Application with the denominations.
